### PR TITLE
Test Coverage For Get State Use Cases

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,13 +4,16 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleHome" value="" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/src/main/kotlin/logic/exception/PlanMateException.kt
+++ b/src/main/kotlin/logic/exception/PlanMateException.kt
@@ -22,9 +22,9 @@ sealed class PlanMateException : Exception() {
     }
 
     sealed class NotFoundException : PlanMateException() {
-        data object ProjectNotFoundException : ParsingException()
-        data object TaskNotFoundException : ParsingException()
-        data object StateNotFoundException : ParsingException()
+        data object ProjectNotFoundException : NotFoundException()
+        data object TaskNotFoundException : NotFoundException()
+        data object StateNotFoundException : NotFoundException()
     }
 
 }

--- a/src/main/kotlin/logic/usecases/state/GetProjectStatesUseCase.kt
+++ b/src/main/kotlin/logic/usecases/state/GetProjectStatesUseCase.kt
@@ -7,6 +7,6 @@ class GetProjectStatesUseCase(private val repository: ProjectRepository) {
 
     fun getProjectStatesByProjectID(id: UUID): List<String> {
 
-        return listOf()
+        return repository.getProject(id).states
     }
 }

--- a/src/main/kotlin/logic/usecases/state/GetProjectStatesUseCase.kt
+++ b/src/main/kotlin/logic/usecases/state/GetProjectStatesUseCase.kt
@@ -5,8 +5,8 @@ import java.util.UUID
 
 class GetProjectStatesUseCase(private val repository: ProjectRepository) {
 
-    fun execute(projectID: UUID): List<String> {
+    fun execute(projectID: String): List<String> {
 
-        return repository.getProject(projectID).states
+        return repository.getProject(UUID.fromString(projectID)).states
     }
 }

--- a/src/main/kotlin/logic/usecases/state/GetProjectStatesUseCase.kt
+++ b/src/main/kotlin/logic/usecases/state/GetProjectStatesUseCase.kt
@@ -5,8 +5,8 @@ import java.util.UUID
 
 class GetProjectStatesUseCase(private val repository: ProjectRepository) {
 
-    fun getProjectStatesByProjectID(id: UUID): List<String> {
+    fun execute(projectID: UUID): List<String> {
 
-        return repository.getProject(id).states
+        return repository.getProject(projectID).states
     }
 }

--- a/src/main/kotlin/logic/usecases/state/GetProjectStatesUseCase.kt
+++ b/src/main/kotlin/logic/usecases/state/GetProjectStatesUseCase.kt
@@ -1,0 +1,12 @@
+package logic.usecases.state
+
+import logic.repository.ProjectRepository
+import java.util.UUID
+
+class GetProjectStatesUseCase(private val repository: ProjectRepository) {
+
+    fun getProjectStatesByProjectID(id: UUID): List<String> {
+
+        return listOf()
+    }
+}

--- a/src/main/kotlin/logic/usecases/state/GetTaskStateUseCase.kt
+++ b/src/main/kotlin/logic/usecases/state/GetTaskStateUseCase.kt
@@ -5,8 +5,8 @@ import java.util.UUID
 
 class GetTaskStateUseCase(private val repository: TaskRepository) {
 
-    fun execute(taskID: UUID): String {
+    fun execute(taskID: String): String {
 
-        return repository.getTaskById(taskID).state
+        return repository.getTaskById(UUID.fromString(taskID)).state
     }
 }

--- a/src/main/kotlin/logic/usecases/state/GetTaskStateUseCase.kt
+++ b/src/main/kotlin/logic/usecases/state/GetTaskStateUseCase.kt
@@ -5,7 +5,8 @@ import java.util.UUID
 
 class GetTaskStateUseCase(private val repository: TaskRepository) {
 
-    fun getTaskStateByTaskID(id: UUID): String {
-        return ""
+    fun execute(taskID: UUID): String {
+
+        return repository.getTaskById(taskID).state
     }
 }

--- a/src/main/kotlin/logic/usecases/state/GetTaskStateUseCase.kt
+++ b/src/main/kotlin/logic/usecases/state/GetTaskStateUseCase.kt
@@ -1,0 +1,11 @@
+package logic.usecases.state
+
+import logic.repository.TaskRepository
+import java.util.UUID
+
+class GetTaskStateUseCase(private val repository: TaskRepository) {
+
+    fun getTaskStateByTaskID(id: UUID): String {
+        return ""
+    }
+}

--- a/src/test/kotlin/logic/usecases/state/GetProjectStatesUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecases/state/GetProjectStatesUseCaseTest.kt
@@ -1,0 +1,48 @@
+package logic.usecases.state
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import logic.exception.PlanMateException.NotFoundException.*
+import logic.repository.ProjectRepository
+import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.EXPECTED_PROJECT_STATES
+import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.existingProjectID
+import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.notExistingProjectID
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class GetProjectStatesUseCaseTest{
+
+    private lateinit var repository: ProjectRepository
+    private lateinit var useCase: GetProjectStatesUseCase
+
+    @BeforeEach
+    fun setup() {
+        repository = mockk(relaxed = true)
+        useCase = GetProjectStatesUseCase(repository)
+    }
+
+    @Test
+    fun `should return the correct states when the project exists`() {
+        //Given & When
+        val states = useCase.getProjectStatesByProjectID(existingProjectID)
+
+        //Then
+        assertThat(states).containsExactly(EXPECTED_PROJECT_STATES)
+    }
+
+    @Test
+    fun `should return sorted states by creation date when the project exists`() {
+        //Given & When
+        val states = useCase.getProjectStatesByProjectID(existingProjectID)
+
+        //Then
+        assertThat(states).containsExactly(EXPECTED_PROJECT_STATES).inOrder()
+    }
+
+    @Test
+    fun `should throw ProjectNotFoundException when the task is not exists`() {
+        //Given & When & Then
+        assertThrows<ProjectNotFoundException> { useCase.getProjectStatesByProjectID(notExistingProjectID) }
+    }
+}

--- a/src/test/kotlin/logic/usecases/state/GetProjectStatesUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecases/state/GetProjectStatesUseCaseTest.kt
@@ -6,11 +6,10 @@ import io.mockk.mockk
 import logic.exception.PlanMateException.NotFoundException.*
 import logic.exception.PlanMateException.ValidationException.InvalidTaskIDException
 import logic.repository.ProjectRepository
-import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.EXPECTED_PROJECT_STATES
 import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.dummyProject
-import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.existingProjectID
-import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.invalidProjectID
-import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.notExistingProjectID
+import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.EXISTING_PROJECT_ID
+import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.INVALID_PROJECT_ID
+import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.NOT_EXISTING_PROJECT_ID
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -29,39 +28,27 @@ class GetProjectStatesUseCaseTest{
     @Test
     fun `should return the correct states when the project exists`() {
         //Given
-        every { repository.getProject(existingProjectID) } returns dummyProject
+        every { repository.getProject(any()) } returns dummyProject
 
         //When
-        val states = useCase.execute(existingProjectID)
+        val states = useCase.execute(EXISTING_PROJECT_ID)
 
         //Then
-        assertThat(states).containsAtLeastElementsIn(EXPECTED_PROJECT_STATES)
-    }
-
-    @Test
-    fun `should return sorted states by creation date when the project exists`() {
-        //Given
-        every { repository.getProject(existingProjectID) } returns dummyProject
-
-        //When
-        val states = useCase.execute(existingProjectID)
-
-        //Then
-        assertThat(states).containsAtLeastElementsIn(EXPECTED_PROJECT_STATES).inOrder()
+        assertThat(states).containsAtLeastElementsIn(dummyProject.states)
     }
 
     @Test
     fun `should throw InvalidProjectIDException when the project ID is invalid`() {
         //Given & When & Then
-        assertThrows<InvalidTaskIDException> { useCase.execute(invalidProjectID) }
+        assertThrows<InvalidTaskIDException> { useCase.execute(INVALID_PROJECT_ID) }
     }
 
     @Test
     fun `should throw ProjectNotFoundException when the project is not exists`() {
         //Given
-        every { repository.getProject(notExistingProjectID) } throws  ProjectNotFoundException
+        every { repository.getProject(any()) } throws  ProjectNotFoundException
 
         //When & Then
-        assertThrows<ProjectNotFoundException> { useCase.execute(notExistingProjectID) }
+        assertThrows<ProjectNotFoundException> { useCase.execute(NOT_EXISTING_PROJECT_ID) }
     }
 }

--- a/src/test/kotlin/logic/usecases/state/GetProjectStatesUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecases/state/GetProjectStatesUseCaseTest.kt
@@ -4,10 +4,12 @@ import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
 import logic.exception.PlanMateException.NotFoundException.*
+import logic.exception.PlanMateException.ValidationException.InvalidTaskIDException
 import logic.repository.ProjectRepository
 import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.EXPECTED_PROJECT_STATES
 import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.dummyProject
 import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.existingProjectID
+import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.invalidProjectID
 import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.notExistingProjectID
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -20,7 +22,7 @@ class GetProjectStatesUseCaseTest{
 
     @BeforeEach
     fun setup() {
-        repository = mockk(relaxed = true)
+        repository = mockk()
         useCase = GetProjectStatesUseCase(repository)
     }
 
@@ -30,7 +32,7 @@ class GetProjectStatesUseCaseTest{
         every { repository.getProject(existingProjectID) } returns dummyProject
 
         //When
-        val states = useCase.getProjectStatesByProjectID(existingProjectID)
+        val states = useCase.execute(existingProjectID)
 
         //Then
         assertThat(states).containsAtLeastElementsIn(EXPECTED_PROJECT_STATES)
@@ -42,18 +44,24 @@ class GetProjectStatesUseCaseTest{
         every { repository.getProject(existingProjectID) } returns dummyProject
 
         //When
-        val states = useCase.getProjectStatesByProjectID(existingProjectID)
+        val states = useCase.execute(existingProjectID)
 
         //Then
         assertThat(states).containsAtLeastElementsIn(EXPECTED_PROJECT_STATES).inOrder()
     }
 
     @Test
-    fun `should throw ProjectNotFoundException when the task is not exists`() {
+    fun `should throw InvalidProjectIDException when the project ID is invalid`() {
+        //Given & When & Then
+        assertThrows<InvalidTaskIDException> { useCase.execute(invalidProjectID) }
+    }
+
+    @Test
+    fun `should throw ProjectNotFoundException when the project is not exists`() {
         //Given
         every { repository.getProject(notExistingProjectID) } throws  ProjectNotFoundException
 
-        // & When & Then
-        assertThrows<ProjectNotFoundException> { useCase.getProjectStatesByProjectID(notExistingProjectID) }
+        //When & Then
+        assertThrows<ProjectNotFoundException> { useCase.execute(notExistingProjectID) }
     }
 }

--- a/src/test/kotlin/logic/usecases/state/GetProjectStatesUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecases/state/GetProjectStatesUseCaseTest.kt
@@ -1,10 +1,12 @@
 package logic.usecases.state
 
 import com.google.common.truth.Truth.assertThat
+import io.mockk.every
 import io.mockk.mockk
 import logic.exception.PlanMateException.NotFoundException.*
 import logic.repository.ProjectRepository
 import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.EXPECTED_PROJECT_STATES
+import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.dummyProject
 import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.existingProjectID
 import logic.usecases.state.testFactory.GetProjectStatesUseCaseTestFactory.notExistingProjectID
 import org.junit.jupiter.api.BeforeEach
@@ -24,25 +26,34 @@ class GetProjectStatesUseCaseTest{
 
     @Test
     fun `should return the correct states when the project exists`() {
-        //Given & When
+        //Given
+        every { repository.getProject(existingProjectID) } returns dummyProject
+
+        //When
         val states = useCase.getProjectStatesByProjectID(existingProjectID)
 
         //Then
-        assertThat(states).containsExactly(EXPECTED_PROJECT_STATES)
+        assertThat(states).containsAtLeastElementsIn(EXPECTED_PROJECT_STATES)
     }
 
     @Test
     fun `should return sorted states by creation date when the project exists`() {
-        //Given & When
+        //Given
+        every { repository.getProject(existingProjectID) } returns dummyProject
+
+        //When
         val states = useCase.getProjectStatesByProjectID(existingProjectID)
 
         //Then
-        assertThat(states).containsExactly(EXPECTED_PROJECT_STATES).inOrder()
+        assertThat(states).containsAtLeastElementsIn(EXPECTED_PROJECT_STATES).inOrder()
     }
 
     @Test
     fun `should throw ProjectNotFoundException when the task is not exists`() {
-        //Given & When & Then
+        //Given
+        every { repository.getProject(notExistingProjectID) } throws  ProjectNotFoundException
+
+        // & When & Then
         assertThrows<ProjectNotFoundException> { useCase.getProjectStatesByProjectID(notExistingProjectID) }
     }
 }

--- a/src/test/kotlin/logic/usecases/state/GetTaskStateUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecases/state/GetTaskStateUseCaseTest.kt
@@ -1,11 +1,15 @@
 package logic.usecases.state
 
 import com.google.common.truth.Truth.assertThat
+import io.mockk.every
 import io.mockk.mockk
-import logic.exception.PlanMateException.NotFoundException.*
+import logic.exception.PlanMateException.NotFoundException.TaskNotFoundException
+import logic.exception.PlanMateException.ValidationException.InvalidTaskIDException
 import logic.repository.TaskRepository
 import logic.usecases.state.testFactory.GetTaskStateUseCaseTestFactory.EXPECTED_TASK_STATE
+import logic.usecases.state.testFactory.GetTaskStateUseCaseTestFactory.existingTask
 import logic.usecases.state.testFactory.GetTaskStateUseCaseTestFactory.existingTaskID
+import logic.usecases.state.testFactory.GetTaskStateUseCaseTestFactory.invalidTaskID
 import logic.usecases.state.testFactory.GetTaskStateUseCaseTestFactory.notExistingTaskID
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
@@ -18,23 +22,36 @@ class GetTaskStateUseCaseTest {
 
     @BeforeEach
     fun setup() {
-        repository = mockk(relaxed = true)
+        repository = mockk()
         useCase = GetTaskStateUseCase(repository)
     }
 
     @Test
     fun `should return the correct state when the task exists`() {
-        //Given & When
-        val state = useCase.getTaskStateByTaskID(existingTaskID)
+        //Given
+        every { repository.getTaskById(any()) } returns existingTask
+
+        //When
+        val state = useCase.execute(existingTaskID)
 
         //Then
         assertThat(state).isEqualTo(EXPECTED_TASK_STATE)
     }
 
     @Test
-    fun `should throw TaskNotFoundException when the task is not exists`() {
+    fun `should throw InvalidTaskIDException when the task ID is invalid`() {
         //Given & When & Then
-        assertThrows<TaskNotFoundException> { useCase.getTaskStateByTaskID(notExistingTaskID) }
+        assertThrows<InvalidTaskIDException> { useCase.execute(invalidTaskID) }
     }
+
+    @Test
+    fun `should throw TaskNotFoundException when the task is not exists`() {
+        //Given
+        every { repository.getTaskById(any()) } throws TaskNotFoundException
+
+        //When & Then
+        assertThrows<TaskNotFoundException> { useCase.execute(notExistingTaskID) }
+    }
+
 
 }

--- a/src/test/kotlin/logic/usecases/state/GetTaskStateUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecases/state/GetTaskStateUseCaseTest.kt
@@ -1,0 +1,40 @@
+package logic.usecases.state
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import logic.exception.PlanMateException.NotFoundException.*
+import logic.repository.TaskRepository
+import logic.usecases.state.testFactory.GetTaskStateUseCaseTestFactory.EXPECTED_TASK_STATE
+import logic.usecases.state.testFactory.GetTaskStateUseCaseTestFactory.existingTaskID
+import logic.usecases.state.testFactory.GetTaskStateUseCaseTestFactory.notExistingTaskID
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+
+class GetTaskStateUseCaseTest {
+
+    private lateinit var repository: TaskRepository
+    private lateinit var useCase: GetTaskStateUseCase
+
+    @BeforeEach
+    fun setup() {
+        repository = mockk(relaxed = true)
+        useCase = GetTaskStateUseCase(repository)
+    }
+
+    @Test
+    fun `should return the correct state when the task exists`() {
+        //Given & When
+        val state = useCase.getTaskStateByTaskID(existingTaskID)
+
+        //Then
+        assertThat(state).isEqualTo(EXPECTED_TASK_STATE)
+    }
+
+    @Test
+    fun `should throw TaskNotFoundException when the task is not exists`() {
+        //Given & When & Then
+        assertThrows<TaskNotFoundException> { useCase.getTaskStateByTaskID(notExistingTaskID) }
+    }
+
+}

--- a/src/test/kotlin/logic/usecases/state/testFactory/GetProjectStatesUseCaseTestFactory.kt
+++ b/src/test/kotlin/logic/usecases/state/testFactory/GetProjectStatesUseCaseTestFactory.kt
@@ -4,14 +4,14 @@ import logic.entities.Project
 import java.util.*
 
 object GetProjectStatesUseCaseTestFactory {
-    val existingProjectID: UUID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
-    val invalidProjectID: UUID = UUID.fromString("xyz")
-    val notExistingProjectID: UUID = UUID.fromString("4444567-e44b-44d3-a456-426614174000")
+    const val EXISTING_PROJECT_ID: String = "123e4567-e89b-12d3-a456-426614174000"
+    const val INVALID_PROJECT_ID: String = "xyz"
+    const val NOT_EXISTING_PROJECT_ID: String = "4444567-e44b-44d3-a456-426614174000"
 
-    val EXPECTED_PROJECT_STATES: List<String> = listOf("to-do", "in progress", "done")
+    private val EXPECTED_PROJECT_STATES: List<String> = listOf("to-do", "in progress", "done")
 
     val dummyProject = Project(
-        id = existingProjectID,
+        id = UUID.fromString(EXISTING_PROJECT_ID),
         name = "PlanMate",
         states = EXPECTED_PROJECT_STATES,
         tasks = emptyList()

--- a/src/test/kotlin/logic/usecases/state/testFactory/GetProjectStatesUseCaseTestFactory.kt
+++ b/src/test/kotlin/logic/usecases/state/testFactory/GetProjectStatesUseCaseTestFactory.kt
@@ -1,5 +1,6 @@
 package logic.usecases.state.testFactory
 
+import logic.entities.Project
 import java.util.*
 
 object GetProjectStatesUseCaseTestFactory {
@@ -8,4 +9,10 @@ object GetProjectStatesUseCaseTestFactory {
 
     val EXPECTED_PROJECT_STATES: List<String> = listOf("to-do", "in progress", "done")
 
+    val dummyProject = Project(
+        id = existingProjectID,
+        name = "PlanMate",
+        states = EXPECTED_PROJECT_STATES,
+        tasks = emptyList()
+    )
 }

--- a/src/test/kotlin/logic/usecases/state/testFactory/GetProjectStatesUseCaseTestFactory.kt
+++ b/src/test/kotlin/logic/usecases/state/testFactory/GetProjectStatesUseCaseTestFactory.kt
@@ -4,8 +4,9 @@ import logic.entities.Project
 import java.util.*
 
 object GetProjectStatesUseCaseTestFactory {
-    val existingProjectID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
-    val notExistingProjectID = UUID.fromString("4444567-e44b-44d3-a456-426614174000")
+    val existingProjectID: UUID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+    val invalidProjectID: UUID = UUID.fromString("xyz")
+    val notExistingProjectID: UUID = UUID.fromString("4444567-e44b-44d3-a456-426614174000")
 
     val EXPECTED_PROJECT_STATES: List<String> = listOf("to-do", "in progress", "done")
 

--- a/src/test/kotlin/logic/usecases/state/testFactory/GetProjectStatesUseCaseTestFactory.kt
+++ b/src/test/kotlin/logic/usecases/state/testFactory/GetProjectStatesUseCaseTestFactory.kt
@@ -1,0 +1,11 @@
+package logic.usecases.state.testFactory
+
+import java.util.*
+
+object GetProjectStatesUseCaseTestFactory {
+    val existingProjectID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+    val notExistingProjectID = UUID.fromString("4444567-e44b-44d3-a456-426614174000")
+
+    val EXPECTED_PROJECT_STATES: List<String> = listOf("to-do", "in progress", "done")
+
+}

--- a/src/test/kotlin/logic/usecases/state/testFactory/GetTaskStateUseCaseTestFactory.kt
+++ b/src/test/kotlin/logic/usecases/state/testFactory/GetTaskStateUseCaseTestFactory.kt
@@ -4,16 +4,18 @@ import logic.entities.Task
 import java.util.*
 
 object GetTaskStateUseCaseTestFactory {
-    private val existingProjectID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+    private const val existingProjectID = "123e4567-e89b-12d3-a456-426614174000"
     const val EXPECTED_TASK_STATE = "done"
-    val existingTaskID: UUID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
-    val notExistingTaskID: UUID = UUID.randomUUID()
-    val invalidTaskID: UUID = UUID.randomUUID()
+    const val existingTaskID = "123e4567-e89b-12d3-a456-426614174000"
+
+    val notExistingTaskID = UUID.randomUUID().toString()
+
+    const val invalidTaskID = "xyz"
 
     val existingTask = Task(
-            id = existingTaskID,
+            id = UUID.fromString(existingTaskID),
             name = "Add View State Feature",
-            projectId = existingProjectID,
+            projectId =  UUID.fromString(existingProjectID),
             state = EXPECTED_TASK_STATE
         )
 

--- a/src/test/kotlin/logic/usecases/state/testFactory/GetTaskStateUseCaseTestFactory.kt
+++ b/src/test/kotlin/logic/usecases/state/testFactory/GetTaskStateUseCaseTestFactory.kt
@@ -1,9 +1,21 @@
 package logic.usecases.state.testFactory
 
+import logic.entities.Task
 import java.util.*
 
 object GetTaskStateUseCaseTestFactory {
-    val existingTaskID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
-    val notExistingTaskID = UUID.fromString("4444567-e44b-44d3-a456-426614174000")
+    private val existingProjectID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
     const val EXPECTED_TASK_STATE = "done"
+    val existingTaskID: UUID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+    val notExistingTaskID: UUID = UUID.randomUUID()
+    val invalidTaskID: UUID = UUID.randomUUID()
+
+    val existingTask = Task(
+            id = existingTaskID,
+            name = "Add View State Feature",
+            projectId = existingProjectID,
+            state = EXPECTED_TASK_STATE
+        )
+
+
 }

--- a/src/test/kotlin/logic/usecases/state/testFactory/GetTaskStateUseCaseTestFactory.kt
+++ b/src/test/kotlin/logic/usecases/state/testFactory/GetTaskStateUseCaseTestFactory.kt
@@ -1,0 +1,9 @@
+package logic.usecases.state.testFactory
+
+import java.util.*
+
+object GetTaskStateUseCaseTestFactory {
+    val existingTaskID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+    val notExistingTaskID = UUID.fromString("4444567-e44b-44d3-a456-426614174000")
+    const val EXPECTED_TASK_STATE = "done"
+}


### PR DESCRIPTION
This PR adds tests for the `GetTaskStateUseCase `and `GetProjectStatesUseCase `functionality.

- Added the initial  for both `GetTaskStateUseCase` and  `GetProjectStatesUseCase  `class to be used for testing purposes.
- Created a `GetTaskStateUseCaseTestFactory`  and `GetProjectStateUseCaseTestFactory `with fake data for task state testing.

Implemented unit tests for `GetTaskStateUseCase`, including:

- A test to check the correct task state is returned when the task exists.
- A test to check that a `TaskNotFoundException` is thrown when the task does not exist.

Implemented unit tests for `GetTaskStateUseCase`, including:

- A test to check the correct project states is returned when the project exists.
- A test to check that a `ProjectNotFoundException` is thrown when the project does not exist.