### PR TITLE
Add Comprehensive Test Coverage for EditProject Use Case and UI

### DIFF
--- a/src/main/kotlin/data/repository/project/ProjectRepositoryImpl.kt
+++ b/src/main/kotlin/data/repository/project/ProjectRepositoryImpl.kt
@@ -2,6 +2,7 @@ package data.repository.project
 
 import data.datasources.DataSource
 import logic.entities.Project
+import logic.exception.PlanMateException
 import logic.exception.PlanMateException.ValidationException.ProjectNameAlreadyExistException
 
 import logic.repository.ProjectRepository
@@ -17,7 +18,19 @@ class ProjectRepositoryImpl(val dataSource: DataSource) : ProjectRepository {
     }
 
     override fun updateProjectNameById(id: UUID, newName: String) {
-        TODO("Not yet implemented")
+        val allProjects = dataSource.getAll().map { it as Project }
+
+        val existingProject = dataSource.getById(id) as Project
+
+
+        val updatedProject = existingProject.copy(name = newName)
+
+        val updatedProjects = allProjects
+            .filterNot { it.id == id }
+            .toMutableList()
+            .apply { add(updatedProject) }
+
+        dataSource.saveAll(updatedProjects)
     }
 
     override fun deleteProject(projectId: UUID) {
@@ -36,7 +49,8 @@ class ProjectRepositoryImpl(val dataSource: DataSource) : ProjectRepository {
 
     override fun updateProjectStateById(id: UUID, oldState: String, newState: String) {
         val projects = dataSource.getAll().map { it as Project }
-        val project = projects.find { it.id == id } ?: throw PlanMateException.NotFoundException.ProjectNotFoundException
+        val project =
+            projects.find { it.id == id } ?: throw PlanMateException.NotFoundException.ProjectNotFoundException
 
         val updatedProject = project.copy(
             states = project.states.map {
@@ -50,9 +64,10 @@ class ProjectRepositoryImpl(val dataSource: DataSource) : ProjectRepository {
         dataSource.saveAll(updatedProjects)
     }
 
-    override fun deleteStateById(id: UUID, oldState: UUID?) {
+    override fun deleteStateById(projectId: UUID, oldState: String) {
         TODO("Not yet implemented")
     }
+
 
     override fun addStateById(id: UUID, state: String) {
         TODO("Not yet implemented")

--- a/src/main/kotlin/logic/logging/LogEvent.kt
+++ b/src/main/kotlin/logic/logging/LogEvent.kt
@@ -1,0 +1,9 @@
+package logic.logging
+
+import java.util.*
+
+sealed class LogEvent {
+    data class ProjectCreated(val projectId: UUID) : LogEvent()
+    data class ProjectNameUpdated(val projectId: UUID, val oldName: String, val newName: String) : LogEvent()
+    data object InvalidActionAttempted : LogEvent()
+}

--- a/src/main/kotlin/logic/logging/LogEventExtention.kt
+++ b/src/main/kotlin/logic/logging/LogEventExtention.kt
@@ -1,0 +1,31 @@
+package logic.logging
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import logic.entities.LogItem
+import java.util.*
+
+fun LogEvent.toLogItem(userId: UUID?): LogItem {
+    val message = when (this) {
+        is LogEvent.ProjectCreated ->
+            "Project created successfully with ID: '${projectId}' "
+
+        is LogEvent.ProjectNameUpdated ->
+            "Project name updated from '${oldName}' to '${newName}' for project: '${projectId} by '$userId'"
+
+        LogEvent.InvalidActionAttempted ->
+            "An invalid action was attempted."
+    }
+
+    return LogItem(
+        id = UUID.randomUUID(),
+        message = message,
+        date = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()),
+        entityId = when (this) {
+            is LogEvent.ProjectCreated -> projectId
+            is LogEvent.ProjectNameUpdated -> projectId
+            else -> UUID(0, 0)
+        }
+    )
+}

--- a/src/main/kotlin/logic/usecases/project/EditProjectUseCase.kt
+++ b/src/main/kotlin/logic/usecases/project/EditProjectUseCase.kt
@@ -1,0 +1,40 @@
+package logic.usecases.project
+
+import logic.entities.User
+import logic.exception.PlanMateException
+import logic.logging.LogEvent
+import logic.logging.toLogItem
+import logic.repository.LogRepository
+import logic.repository.ProjectRepository
+import java.util.*
+
+class EditProjectUseCase(
+    private val projectRepository: ProjectRepository,
+    private val logRepository: LogRepository
+) {
+    fun editProjectName(user: User, projectId: UUID, newName: String) {
+        validateAdmin(user)
+        validateProjectName(newName)
+
+        val existingProject = projectRepository.getProject(projectId)
+
+        projectRepository.updateProjectNameById(existingProject.id, newName)
+
+        val logEvent = LogEvent.ProjectNameUpdated(
+            projectId = projectId,
+            oldName = existingProject.name,
+            newName = newName
+        )
+
+        logRepository.addLog(logEvent.toLogItem(user.id))
+    }
+
+    private fun validateAdmin(user: User) {
+        if (!user.isAdmin) throw PlanMateException.AuthorizationException.AdminPrivilegesRequiredException
+    }
+
+
+    private fun validateProjectName(name: String) {
+        if (name.isBlank()) throw PlanMateException.ValidationException.InvalidProjectNameException
+    }
+}

--- a/src/main/kotlin/ui/controller/EditProjectUIController.kt
+++ b/src/main/kotlin/ui/controller/EditProjectUIController.kt
@@ -1,0 +1,30 @@
+package ui.controller
+
+import logic.entities.User
+import logic.usecases.project.EditProjectUseCase
+import ui.utils.getErrorMessageByException
+import java.util.*
+
+class EditProjectUIController(
+    private val editProjectUseCase: EditProjectUseCase
+) {
+    fun handleEditProject(user: User) {
+        try {
+            println("🔧 Edit Project Name")
+
+            print("📌 Enter project ID: ")
+            val projectId = readln().trim().let { UUID.fromString(it) }
+
+            print("✏️ Enter new project name: ")
+            val newName = readln().trim()
+
+            editProjectUseCase.editProjectName(user, projectId, newName)
+
+            println("✅ Project name updated successfully!")
+
+        } catch (e: Exception) {
+            val message = getErrorMessageByException(e)
+            println("❌ $message")
+        }
+    }
+}

--- a/src/test/kotlin/helpers/EditProjectFactory.kt
+++ b/src/test/kotlin/helpers/EditProjectFactory.kt
@@ -1,0 +1,48 @@
+package helpers
+
+import logic.entities.Project
+import logic.entities.User
+import java.util.*
+
+object EditProjectFactory {
+
+    val validProjectId: UUID = UUID.randomUUID()
+
+    fun validProject(): Project {
+        return createProject(
+            id = validProjectId,
+            name = "Test Project",
+            states = listOf("TODO", "IN_PROGRESS"),
+            tasks = emptyList()
+        )
+    }
+
+    fun simulateUserInputs(vararg userInputs: String): AutoCloseable {
+        val originalSystemIn = System.`in`
+        val fakeInputStream = userInputs.joinToString("\n").plus("\n").byteInputStream()
+        System.setIn(fakeInputStream)
+
+        return AutoCloseable {
+            System.setIn(originalSystemIn)
+        }
+    }
+
+    fun adminUser(): User {
+        return createUser(
+            isAdmin = true,
+            username = "admin",
+            password = "admin123"
+        )
+    }
+
+    fun projectList(): List<Project> {
+        return listOf(
+            createProject(UUID.randomUUID(), "Project A", listOf("TODO"), emptyList()),
+            createProject(UUID.randomUUID(), "Project B", listOf("IN_PROGRESS"), emptyList())
+        )
+    }
+
+    val mateUser = adminUser().copy(isAdmin = false)
+
+
+}

--- a/src/test/kotlin/helpers/TestObjectCreator.kt
+++ b/src/test/kotlin/helpers/TestObjectCreator.kt
@@ -1,0 +1,31 @@
+package helpers
+
+import logic.entities.Project
+import logic.entities.Task
+import logic.entities.User
+import java.util.*
+
+fun createProject(
+    id: UUID,
+    name: String,
+    states: List<String>,
+    tasks: List<Task>
+): Project {
+    return Project(
+        id = id,
+        name = name,
+        states = states,
+        tasks = tasks
+    )
+}
+fun createUser(
+    id: UUID = UUID.randomUUID(),
+    isAdmin: Boolean = false,
+    username: String = "user1",
+    password: String = "123456"
+): User = User(
+    id = id,
+    isAdmin = isAdmin,
+    username = username,
+    password = password
+)

--- a/src/test/kotlin/logic/usecases/project/EditProjectUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecases/project/EditProjectUseCaseTest.kt
@@ -1,0 +1,112 @@
+package logic.usecases.project
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import logic.exception.PlanMateException
+import helpers.EditProjectFactory
+import logic.logging.LogEvent
+import logic.logging.toLogItem
+import logic.repository.LogRepository
+import logic.repository.ProjectRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class EditProjectUseCaseTest {
+
+    private lateinit var projectRepository: ProjectRepository
+    private lateinit var editProjectUseCase: EditProjectUseCase
+    private lateinit var logRepository: LogRepository
+
+
+    @BeforeEach
+    fun setup() {
+        projectRepository = mockk(relaxed = true)
+        logRepository = mockk(relaxed = true)
+        editProjectUseCase = EditProjectUseCase(projectRepository, logRepository)
+    }
+
+    @Test
+    fun `should update project name when user is admin and project exists`() {
+        // Given
+        val newName = "Updated Project Name"
+        every { projectRepository.getProject(EditProjectFactory.validProjectId) } returns EditProjectFactory.validProject()
+
+        // When
+        editProjectUseCase.editProjectName(EditProjectFactory.adminUser(), EditProjectFactory.validProjectId, newName)
+
+        // Then
+        verify { projectRepository.updateProjectNameById(EditProjectFactory.validProjectId, newName) }
+    }
+
+    @Test
+    fun `should throw AdminPrivilegesRequiredException when user is not admin`() {
+        // Given
+        val newName = "Updated Project Name"
+
+        // When & Then
+        assertThrows<PlanMateException.AuthorizationException.AdminPrivilegesRequiredException>
+        { editProjectUseCase.editProjectName(EditProjectFactory.mateUser, EditProjectFactory.validProjectId, newName) }
+    }
+
+    @Test
+    fun `should throw ProjectNotFoundException when project with id does not exist`() {
+        // Given
+        val newName = "Updated Project Name"
+
+        every { projectRepository.getProjects() } returns EditProjectFactory.projectList()
+
+        // When & Then
+        assertThrows<PlanMateException.NotFoundException.ProjectNotFoundException> {
+            editProjectUseCase.editProjectName(
+                EditProjectFactory.adminUser(),
+                EditProjectFactory.validProjectId,
+                newName
+            )
+        }
+    }
+
+    @Test
+    fun `should throw InvalidProjectNameException when new name is blank`() {
+        // Given
+        val newName = "   "
+        every { projectRepository.getProject(EditProjectFactory.validProjectId) } returns EditProjectFactory.validProject()
+
+        // When & Then
+        assertThrows<PlanMateException.ValidationException.InvalidProjectNameException> {
+            editProjectUseCase.editProjectName(
+                EditProjectFactory.adminUser(),
+                EditProjectFactory.validProjectId,
+                newName
+            )
+        }
+    }
+
+    @Test
+    fun `should add log entry when project name is updated`() {
+        // Given
+        every { projectRepository.getProject(EditProjectFactory.validProjectId) } returns EditProjectFactory.validProject()
+
+        val newName = "Updated Project Name"
+
+        // When
+        editProjectUseCase.editProjectName(EditProjectFactory.adminUser(), EditProjectFactory.validProjectId, newName)
+
+        val event = LogEvent.ProjectNameUpdated(
+            projectId = EditProjectFactory.validProjectId,
+            oldName = EditProjectFactory.validProject().name,
+            newName = newName
+        )
+        val logItem = event.toLogItem(EditProjectFactory.adminUser().id)
+
+        // Then
+        verify {
+            logRepository.addLog(logItem)
+        }
+    }
+}
+
+
+
+

--- a/src/test/kotlin/ui/project/EditProjectUIControllerTest.kt
+++ b/src/test/kotlin/ui/project/EditProjectUIControllerTest.kt
@@ -1,0 +1,77 @@
+package ui.project
+
+import io.mockk.mockk
+import helpers.EditProjectFactory
+import logic.usecases.project.EditProjectUseCase
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import ui.controller.EditProjectUIController
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import kotlin.test.assertTrue
+
+class EditProjectUIControllerTest {
+
+    private lateinit var editProjectUseCase: EditProjectUseCase
+    private lateinit var controller: EditProjectUIController
+
+    private val outputStreamCaptor = ByteArrayOutputStream()
+    private val originalOut = System.out
+
+    @BeforeEach
+    fun setUp() {
+        System.setOut(PrintStream(outputStreamCaptor))
+        editProjectUseCase = mockk()
+        controller = EditProjectUIController(editProjectUseCase)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        System.setOut(originalOut)
+    }
+
+    @Test
+    fun `should print success message when project is edited successfully`() {
+
+        EditProjectFactory.simulateUserInputs(EditProjectFactory.validProjectId.toString(), "Updated Project").use {
+            controller.handleEditProject(EditProjectFactory.adminUser())
+        }
+
+        val output = outputStreamCaptor.toString().trim()
+        assertTrue(output.contains("✅ Project name updated successfully!"))
+    }
+
+    @Test
+    fun `should print error when project name is blank`() {
+
+        EditProjectFactory.simulateUserInputs(EditProjectFactory.validProjectId.toString(), "   ").use {
+            controller.handleEditProject(EditProjectFactory.adminUser())
+        }
+
+        val output = outputStreamCaptor.toString().trim()
+        assertTrue(output.contains("❌ Project name cannot be empty. Please provide a valid name."))
+    }
+
+    @Test
+    fun `should print error when input project ID is invalid`() {
+        EditProjectFactory.simulateUserInputs("not-a-uuid", "New Project Name").use {
+            controller.handleEditProject(EditProjectFactory.adminUser())
+        }
+
+        val output = outputStreamCaptor.toString().trim()
+        assertTrue(output.contains("❌ Invalid input format. Please enter a valid UUID."))
+    }
+
+    @Test
+    fun `should print error when user is not admin`() {
+
+        EditProjectFactory.simulateUserInputs(EditProjectFactory.validProjectId.toString(), "Another Name").use {
+            controller.handleEditProject(EditProjectFactory.mateUser)
+        }
+
+        val output = outputStreamCaptor.toString().trim()
+        assertTrue(output.contains("❌ You don’t have permission to perform this action. Admin privileges required."))
+    }
+
+}


### PR DESCRIPTION
This PR adds unit and UI test coverage for the "Edit Project Name" feature.
Below is a description of each test-related file included:

1.**EditProjectUseCaseTest**

**Purpose:** Unit tests for the business use case of editing a project name.
 **What it covers:**

-  Validates that project names can be successfully updated by an admin.
-  Asserts that exceptions are thrown for invalid input (non-admins, blank names, nonexistent project ID).
-  Confirms logging behavior when a project is updated.

2.**EditProjectUIControllerTest**

 **Purpose:** Tests the UI controller that handles user input/output in the console.
 **What it covers:**

-   Simulates user input via console to trigger project name editing.
-   Validates success and failure messages depending on input validity and user permissions.
-   Covers edge cases like invalid UUIDs and empty project names.

3.**EditProjectFactory**

**Purpose:** Centralized factory for creating fake project and user data for test scenarios.
**What it includes:**

-   `validProject()` and `validProjectId`: Used across tests to represent a valid project.
-   `adminUser()` and `mateUser`: Admin vs. non-admin user setup.
-   `simulateUserInputs()`: Utility to simulate console input for UI tests.
-   `projectList()`: Provides a list of sample projects for tests needing multiple entries.


4.**TestHelperFunctions** 
**Purpose:** Provides reusable functions like `createProject()` and `createUser()` for consistency across test files.
**Why it's useful:** Ensures test data is consistent, reusable, and maintainable for all team members.




