### PR TITLE
Add Edit Project Name Use Case with Validation and Logging Support

### DIFF
--- a/src/main/kotlin/data/repository/project/ProjectRepositoryImpl.kt
+++ b/src/main/kotlin/data/repository/project/ProjectRepositoryImpl.kt
@@ -2,6 +2,7 @@ package data.repository.project
 
 import data.datasources.DataSource
 import logic.entities.Project
+import logic.exception.PlanMateException
 import logic.exception.PlanMateException.ValidationException.ProjectNameAlreadyExistException
 
 import logic.repository.ProjectRepository
@@ -17,7 +18,19 @@ class ProjectRepositoryImpl(val dataSource: DataSource) : ProjectRepository {
     }
 
     override fun updateProjectNameById(id: UUID, newName: String) {
-        TODO("Not yet implemented")
+        val allProjects = dataSource.getAll().map { it as Project }
+
+        val existingProject = dataSource.getById(id) as Project
+
+
+        val updatedProject = existingProject.copy(name = newName)
+
+        val updatedProjects = allProjects
+            .filterNot { it.id == id }
+            .toMutableList()
+            .apply { add(updatedProject) }
+
+        dataSource.saveAll(updatedProjects)
     }
 
     override fun deleteProject(projectId: UUID) {
@@ -36,7 +49,8 @@ class ProjectRepositoryImpl(val dataSource: DataSource) : ProjectRepository {
 
     override fun updateProjectStateById(id: UUID, oldState: String, newState: String) {
         val projects = dataSource.getAll().map { it as Project }
-        val project = projects.find { it.id == id } ?: throw PlanMateException.NotFoundException.ProjectNotFoundException
+        val project =
+            projects.find { it.id == id } ?: throw PlanMateException.NotFoundException.ProjectNotFoundException
 
         val updatedProject = project.copy(
             states = project.states.map {
@@ -50,9 +64,10 @@ class ProjectRepositoryImpl(val dataSource: DataSource) : ProjectRepository {
         dataSource.saveAll(updatedProjects)
     }
 
-    override fun deleteStateById(id: UUID, oldState: UUID?) {
+    override fun deleteStateById(projectId: UUID, oldState: String) {
         TODO("Not yet implemented")
     }
+
 
     override fun addStateById(id: UUID, state: String) {
         TODO("Not yet implemented")

--- a/src/main/kotlin/logic/logging/LogEvent.kt
+++ b/src/main/kotlin/logic/logging/LogEvent.kt
@@ -1,0 +1,9 @@
+package logic.logging
+
+import java.util.*
+
+sealed class LogEvent {
+    data class ProjectCreated(val projectId: UUID) : LogEvent()
+    data class ProjectNameUpdated(val projectId: UUID, val oldName: String, val newName: String) : LogEvent()
+    data object InvalidActionAttempted : LogEvent()
+}

--- a/src/main/kotlin/logic/logging/LogEventExtention.kt
+++ b/src/main/kotlin/logic/logging/LogEventExtention.kt
@@ -1,0 +1,31 @@
+package logic.logging
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import logic.entities.LogItem
+import java.util.*
+
+fun LogEvent.toLogItem(userId: UUID?): LogItem {
+    val message = when (this) {
+        is LogEvent.ProjectCreated ->
+            "Project created successfully with ID: '${projectId}' "
+
+        is LogEvent.ProjectNameUpdated ->
+            "Project name updated from '${oldName}' to '${newName}' for project: '${projectId} by '$userId'"
+
+        LogEvent.InvalidActionAttempted ->
+            "An invalid action was attempted."
+    }
+
+    return LogItem(
+        id = UUID.randomUUID(),
+        message = message,
+        date = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()),
+        entityId = when (this) {
+            is LogEvent.ProjectCreated -> projectId
+            is LogEvent.ProjectNameUpdated -> projectId
+            else -> UUID(0, 0)
+        }
+    )
+}

--- a/src/main/kotlin/logic/usecases/project/EditProjectUseCase.kt
+++ b/src/main/kotlin/logic/usecases/project/EditProjectUseCase.kt
@@ -1,0 +1,40 @@
+package logic.usecases.project
+
+import logic.entities.User
+import logic.exception.PlanMateException
+import logic.logging.LogEvent
+import logic.logging.toLogItem
+import logic.repository.LogRepository
+import logic.repository.ProjectRepository
+import java.util.*
+
+class EditProjectUseCase(
+    private val projectRepository: ProjectRepository,
+    private val logRepository: LogRepository
+) {
+    fun editProjectName(user: User, projectId: UUID, newName: String) {
+        validateAdmin(user)
+        validateProjectName(newName)
+
+        val existingProject = projectRepository.getProject(projectId)
+
+        projectRepository.updateProjectNameById(existingProject.id, newName)
+
+        val logEvent = LogEvent.ProjectNameUpdated(
+            projectId = projectId,
+            oldName = existingProject.name,
+            newName = newName
+        )
+
+        logRepository.addLog(logEvent.toLogItem(user.id))
+    }
+
+    private fun validateAdmin(user: User) {
+        if (!user.isAdmin) throw PlanMateException.AuthorizationException.AdminPrivilegesRequiredException
+    }
+
+
+    private fun validateProjectName(name: String) {
+        if (name.isBlank()) throw PlanMateException.ValidationException.InvalidProjectNameException
+    }
+}

--- a/src/main/kotlin/ui/controller/EditProjectUIController.kt
+++ b/src/main/kotlin/ui/controller/EditProjectUIController.kt
@@ -1,0 +1,30 @@
+package ui.controller
+
+import logic.entities.User
+import logic.usecases.project.EditProjectUseCase
+import ui.utils.getErrorMessageByException
+import java.util.*
+
+class EditProjectUIController(
+    private val editProjectUseCase: EditProjectUseCase
+) {
+    fun handleEditProject(user: User) {
+        try {
+            println("🔧 Edit Project Name")
+
+            print("📌 Enter project ID: ")
+            val projectId = readln().trim().let { UUID.fromString(it) }
+
+            print("✏️ Enter new project name: ")
+            val newName = readln().trim()
+
+            editProjectUseCase.editProjectName(user, projectId, newName)
+
+            println("✅ Project name updated successfully!")
+
+        } catch (e: Exception) {
+            val message = getErrorMessageByException(e)
+            println("❌ $message")
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces the core business logic for editing a project's name. It enforces proper validation, role-based access control, and logging to ensure the action is secure, consistent, and traceable

1. **EditProjectUseCase**

**Purpose:**
Contains the main business logic for editing a project's name.

**Key responsibilities added:**

- Validates that the user has admin privileges before making changes.
- Ensures the new project name is not blank or just whitespace.
- Retrieves the existing project using the provided ID.
- Updates the project's name through the repository.
- Logs the change using a structured event (ProjectNameUpdated) to ensure system traceability.
- This separation of concerns ensures the logic is testable, reusable, and secure.

2. **EditProjectUIController**

**Purpose:**
Provides a CLI interface for admins to edit the project name.

**Enhancements added:**
- Interacts with the user by prompting for project ID and new name.
- Parses and validates the project ID input.
- Delegates the core logic to the EditProjectUseCase.
- Catches exceptions and maps them to meaningful error messages shown to the user



