### PR TITLE
Refactor repository unit tests to be suspend & refactor project repository

### DIFF
--- a/src/main/kotlin/data/repository/project/ProjectRepositoryImpl.kt
+++ b/src/main/kotlin/data/repository/project/ProjectRepositoryImpl.kt
@@ -19,7 +19,6 @@ import java.util.*
 
 class ProjectRepositoryImpl(
     private val projectDataSource: IProjectDataSource,
-    private val logRepository: LogRepository,
 ) : ProjectRepository {
   
     override suspend fun createProject(project: Project): Boolean {
@@ -28,14 +27,6 @@ class ProjectRepositoryImpl(
             throw ProjectNameAlreadyExistException
         }
         projectDataSource.insertProject(project)
-        logRepository.addLog(
-            log = LogItem(
-                id = UUID.randomUUID(),
-                message = "This project is created at that time",
-                date = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()),
-                entityId = project.id
-            )
-        )
         return true
     }
 

--- a/src/main/kotlin/di/appModule.kt
+++ b/src/main/kotlin/di/appModule.kt
@@ -99,7 +99,7 @@ val appModule = module {
     single<AuthRepository> { AuthRepositoryImpl(get()) }
     single<TaskRepository> { TaskRepositoryImpl(get()) }
     single<LogRepository> { LogRepositoryImpl(get()) }
-    single<ProjectRepository> { ProjectRepositoryImpl(get(), get()) }
+    single<ProjectRepository> { ProjectRepositoryImpl(get()) }
     single<StateManager>{ StateManager }
 
 

--- a/src/test/kotlin/data/repository/project/DeleteProjectRepositoryTest.kt
+++ b/src/test/kotlin/data/repository/project/DeleteProjectRepositoryTest.kt
@@ -26,8 +26,7 @@ class DeleteProjectRepositoryTest {
     @BeforeEach
     fun setUp() {
         dataSource = mockk(relaxed = true)
-        logger = mockk(relaxed = true)
-        repository = ProjectRepositoryImpl(dataSource, logger)
+        repository = ProjectRepositoryImpl(dataSource)
         dummyId = randomUUID()
 
     }

--- a/src/test/kotlin/data/repository/project/DeleteProjectRepositoryTest.kt
+++ b/src/test/kotlin/data/repository/project/DeleteProjectRepositoryTest.kt
@@ -1,42 +1,41 @@
 package data.repository.project
 
-import data.datasources.CsvDataSource
+
 import com.google.common.truth.Truth.assertThat
-import data.datasources.projectDataSource.ProjectDataSourceInterface
+import data.datasources.projectDataSource.IProjectDataSource
+import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.runs
-import io.mockk.verify
-import logic.entities.Project
-import logic.exception.PlanMateException.DataSourceException.EmptyDataException
+import kotlinx.coroutines.test.runTest
 import logic.exception.PlanMateException.NotFoundException.ProjectNotFoundException
+import logic.usecases.LoggerUseCase
 import logic.usecases.project.helper.DeleteProjectTestFactory.someProjects
 import org.junit.jupiter.api.Test
 
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 import java.util.UUID.randomUUID
 
 class DeleteProjectRepositoryTest {
-    lateinit var dataSource: ProjectDataSourceInterface
+    lateinit var dataSource: IProjectDataSource
     lateinit var repository: ProjectRepositoryImpl
     lateinit var dummyId: UUID
+    lateinit var logger : LoggerUseCase
 
     @BeforeEach
     fun setUp() {
         dataSource = mockk(relaxed = true)
-        repository = ProjectRepositoryImpl(dataSource)
+        logger = mockk(relaxed = true)
+        repository = ProjectRepositoryImpl(dataSource, logger)
         dummyId = randomUUID()
 
     }
 
     @Test
-    fun `should return true when deleting project complete successfully`() {
+    fun `should return true when deleting project complete successfully`() = runTest{
         // given
-        every { dataSource.deleteProject(someProjects[0].id) } returns true
+        coEvery { dataSource.deleteProject(someProjects[0].id) } returns true
         // when
         val result = repository.deleteProject(someProjects[0].id)
 
@@ -48,9 +47,9 @@ class DeleteProjectRepositoryTest {
 
 
     @Test
-    fun `should throw project not found when deleting project not exist`() {
+    fun `should throw project not found when deleting project not exist`() = runTest{
         // given
-        every { dataSource.deleteProject(someProjects[0].id) } throws ProjectNotFoundException
+        coEvery { dataSource.deleteProject(someProjects[0].id) } throws ProjectNotFoundException
 
         // when & then
         assertThrows <ProjectNotFoundException> {

--- a/src/test/kotlin/data/repository/task/EditTaskRepositoryTest.kt
+++ b/src/test/kotlin/data/repository/task/EditTaskRepositoryTest.kt
@@ -1,16 +1,10 @@
 package data.repository.task
-
 import com.google.common.truth.Truth.assertThat
-import data.datasources.CsvDataSource
-import data.datasources.taskDataSource.TaskDataSourceInterface
-import io.mockk.every
-import io.mockk.just
+import data.datasources.taskDataSource.ITaskDataSource
+import io.mockk.coEvery
 import io.mockk.mockk
-import io.mockk.runs
+import kotlinx.coroutines.test.runTest
 import logic.entities.Task
-import logic.exception.PlanMateException
-import logic.exception.PlanMateException.DataSourceException.EmptyDataException
-import logic.exception.PlanMateException.DataSourceException.EmptyFileException
 import logic.exception.PlanMateException.NotFoundException
 import logic.exception.PlanMateException.NotFoundException.TaskNotFoundException
 import logic.repository.TaskRepository
@@ -22,7 +16,7 @@ import java.util.UUID.randomUUID
 
 class EditTasKRepositoryTest {
 
-    lateinit var dataSource: TaskDataSourceInterface
+    lateinit var dataSource: ITaskDataSource
     lateinit var repository: TaskRepositoryImpl
     lateinit var authenticationTask: Task
 
@@ -40,8 +34,8 @@ class EditTasKRepositoryTest {
     }
 
     @Test
-    fun `should return true when editing task name complete successfully`() {
-        every { dataSource.updateTaskName(taskId = authenticationTask.id, newName = "new name") } returns true
+    fun `should return true when editing task name complete successfully`() = runTest{
+        coEvery { dataSource.updateTaskName(taskId = authenticationTask.id, newName = "new name") } returns true
         val result = repository.updateTaskNameByID(
             taskId = authenticationTask.id,
             newName = "new name"
@@ -52,8 +46,8 @@ class EditTasKRepositoryTest {
     }
 
     @Test
-    fun `should return true when editing task state complete successfully`() {
-        every { dataSource.updateTaskState(taskId = authenticationTask.id, newState = "new state") } returns true
+    fun `should return true when editing task state complete successfully`() = runTest{
+        coEvery { dataSource.updateTaskState(taskId = authenticationTask.id, newState = "new state") } returns true
         val result = repository.updateStateNameByID(
             taskId = authenticationTask.id,
             newState = "new state"
@@ -63,8 +57,8 @@ class EditTasKRepositoryTest {
     }
 
     @Test
-    fun `should throw task not found when editing or updating non existed task`() {
-        every { dataSource.updateTaskState(taskId = authenticationTask.id, newState = "new state") } throws TaskNotFoundException
+    fun `should throw task not found when editing or updating non existed task`()= runTest {
+        coEvery { dataSource.updateTaskState(taskId = authenticationTask.id, newState = "new state") } throws TaskNotFoundException
         assertThrows<NotFoundException> {
             repository.updateStateNameByID(
                 taskId = authenticationTask.id,


### PR DESCRIPTION
## what has been done:
- refactor unit test of edit task repository to be compatible with suspend functions
- refactor unit test of delete project repository to be compatible with suspend functions
- refactor project repository to not depend on log repository to make logs entry, because we standardize the functionality of creating logs to be single use case with configured messages