### PR TITLE
Add Logging Proxy for AuthRepository with Koin Integration

### DIFF
--- a/src/main/kotlin/di/appModule.kt
+++ b/src/main/kotlin/di/appModule.kt
@@ -1,5 +1,6 @@
 package di
 
+import AuthRepositoryLoggingProxy
 import com.mongodb.kotlin.client.coroutine.MongoCollection
 import data.datasources.MongoDatabaseFactory
 import data.datasources.logDataSource.ILogDataSource
@@ -18,7 +19,6 @@ import logic.entities.LogItem
 import logic.entities.Project
 import logic.entities.Task
 import logic.entities.User
-import logic.proxies.AuthRepositoryLoggingProxy
 import logic.repository.AuthRepository
 import logic.repository.LogRepository
 import logic.repository.ProjectRepository
@@ -98,8 +98,9 @@ val appModule = module {
     // Repositories
     single<AuthRepository> {
         val impl = AuthRepositoryImpl(get())
-        AuthRepositoryLoggingProxy(impl)
+        AuthRepositoryLoggingProxy(impl, get())
     }
+
     single<TaskRepository> { TaskRepositoryImpl(get()) }
     single<LogRepository> { LogRepositoryImpl(get()) }
     single<ProjectRepository> { ProjectRepositoryImpl(get()) }

--- a/src/main/kotlin/di/appModule.kt
+++ b/src/main/kotlin/di/appModule.kt
@@ -18,6 +18,7 @@ import logic.entities.LogItem
 import logic.entities.Project
 import logic.entities.Task
 import logic.entities.User
+import logic.proxies.AuthRepositoryLoggingProxy
 import logic.repository.AuthRepository
 import logic.repository.LogRepository
 import logic.repository.ProjectRepository
@@ -95,7 +96,10 @@ val appModule = module {
 
 
     // Repositories
-    single<AuthRepository> { AuthRepositoryImpl(get()) }
+    single<AuthRepository> {
+        val impl = AuthRepositoryImpl(get())
+        AuthRepositoryLoggingProxy(impl)
+    }
     single<TaskRepository> { TaskRepositoryImpl(get()) }
     single<LogRepository> { LogRepositoryImpl(get()) }
     single<ProjectRepository> { ProjectRepositoryImpl(get()) }

--- a/src/main/kotlin/logic/proxies/AuthRepositoryLoggingProxy.kt
+++ b/src/main/kotlin/logic/proxies/AuthRepositoryLoggingProxy.kt
@@ -1,0 +1,51 @@
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import logic.entities.LogItem
+import logic.entities.User
+import logic.repository.AuthRepository
+import logic.repository.LogRepository
+import logic.usecases.utils.StateManager
+import java.util.*
+
+class AuthRepositoryLoggingProxy(
+    private val authRepository: AuthRepository,
+    private val logRepository: LogRepository
+) : AuthRepository {
+
+    override suspend fun login(username: String, password: String): User {
+        val user = authRepository.login(username, password)
+        StateManager.setLoggedInUser(user)
+
+        val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+        val log = LogItem(
+            id = UUID.randomUUID(),
+            message = "User logged in: $username",
+            date = now,
+            entityId = user.id
+        )
+
+        logRepository.addLog(log)
+        return user
+    }
+
+    override suspend fun createUser(user: User): Boolean {
+        val result = authRepository.createUser(user)
+
+        if (result) {
+            val actor = if (StateManager.isUserLoggedIn()) StateManager.getLoggedInUser() else null
+
+            val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+            val log = LogItem(
+                id = UUID.randomUUID(),
+                message = "User created: ${user.username}",
+                date = now,
+                entityId = actor?.id ?: user.id
+            )
+
+            logRepository.addLog(log)
+        }
+
+        return result
+    }
+}


### PR DESCRIPTION
This PR improves system **observability and debuggability by logging authentication events**. It keeps the separation of concerns clean by using the **Proxy Pattern** instead of **bloating use cases with logging logic.**

This is what we did in this PR:
- Introduced `AuthRepositoryLoggingProxy` to wrap the original `AuthRepositoryImpl` implementation.
- The proxy intercepts `login` and `createUser` operations to log authentication-related events using `LogRepository`.
- Ensured integration with Koin DI by updating the `single<AuthRepository>` binding to inject the proxy instead of the raw implementation.